### PR TITLE
Gin no longer uses gopkg.in

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/dpordomingo/go-gingonic-cache/persistence"
+	"github.com/erizocosmico/gin-cache/persistence"
 
-	"gopkg.in/gin-gonic/gin.v1"
+	"github.com/gin-gonic/gin"
 )
 
 const (

--- a/example/example.go
+++ b/example/example.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dpordomingo/go-gingonic-cache"
-	"github.com/dpordomingo/go-gingonic-cache/persistence"
-	"gopkg.in/gin-gonic/gin.v1"
+	"github.com/erizocosmico/gin-cache"
+	"github.com/erizocosmico/gin-cache/persistence"
+
+	"github.com/gin-gonic/gin"
 )
 
 func main() {

--- a/persistence/memcached.go
+++ b/persistence/memcached.go
@@ -3,8 +3,9 @@ package persistence
 import (
 	"time"
 
+	"github.com/erizocosmico/gin-cache/utils"
+
 	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/dpordomingo/go-gingonic-cache/utils"
 )
 
 // MemcachedStore represents the cache with memcached persistence

--- a/persistence/redis.go
+++ b/persistence/redis.go
@@ -3,7 +3,8 @@ package persistence
 import (
 	"time"
 
-	"github.com/dpordomingo/go-gingonic-cache/utils"
+	"github.com/erizocosmico/gin-cache/utils"
+
 	"github.com/garyburd/redigo/redis"
 )
 


### PR DESCRIPTION
blocks: https://github.com/src-d/landing/pull/178

---

from last `gin-cache` commit:
https://github.com/gin-contrib/cache/commit/e23262a6fff8e72226b220c1939d09244ffe4d63

see example from `gin-cors`
https://github.com/gin-contrib/cors/tree/v1.2#user-content-canonical-example
and its code
https://github.com/gin-contrib/cors/blob/v1.2/cors.go